### PR TITLE
Add missing <authors> tag to nuspec file

### DIFF
--- a/My.Awesome.Library.nuspec
+++ b/My.Awesome.Library.nuspec
@@ -3,6 +3,7 @@
   <metadata>
     <id>My.Awesome.Library</id>
     <version>1.0.0</version>
+    <authors>John Doe</authors>
     <title>My Awesome Library</title>
     <description>Herpa Derpa</description>
   </metadata>


### PR DESCRIPTION
Needed to avoid error when running "nuget pack" against the nuspec file.